### PR TITLE
Add dsym generation/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Write a simple Podfile like this:
 ```ruby
 platform :osx, '10.10'
 
-plugin 'cocoapods-rome'
+plugin 'cocoapods-rome' {
+  dsym: true,
+  configuration: 'Release'
+}
 
 target 'caesar' do
   pod 'Alamofire'
@@ -37,6 +40,22 @@ and you will end up with dynamic frameworks:
 $ tree Rome/
 Rome/
 └── Alamofire.framework
+$ tree dSYM/
+dSYM/
+├── iphoneos
+│   └── Alamofire.framework.dSYM
+│       └── Contents
+│           ├── Info.plist
+│           └── Resources
+│               └── DWARF
+│                   └── Alamofire
+└── iphonesimulator
+    └── Alamofire.framework.dSYM
+        └── Contents
+            ├── Info.plist
+            └── Resources
+                └── DWARF
+                    └── Alamofire
 ```
 
 ## Hooks


### PR DESCRIPTION
Cocoapods Rome is a great alternative for [Carthage](https://github.com/Carthage/Carthage) if you depend on libraries that don't support Carthage yet and you'd like to avoid the CocoaPods integration with the user project. The only thing missing is that you can't debug the third party frameworks properly because the dSYM information is deleted after build and it defaults to "Release" configuration which has compiler optimisations that affect the debugger (wrong stepping and missing variable).

This PR includes the following:
* Exports the dSYM information per platforms somewhere accessible by the user project. You just need to add a run script phase with something like: `cp -R "${SOURCE_ROOT}/third_party_dependencies/dSYM/${PLATFORM_NAME}"/* $BUILT_PRODUCTS_DIR ` to copy the output to the right place.
* Reads a environment variable to determine which configuration should be used to compile the frameworks. Not sure if there's a better way to pass parameters into a plugin, that'll be certainly ideal. 