### PR TITLE
Fix overwrite issue with dependencies that have the same base dependencies

### DIFF
--- a/lib/cocoapods-rome/gem_version.rb
+++ b/lib/cocoapods-rome/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsRome
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -24,8 +24,8 @@ def build_for_iosish_platform(sandbox, build_dir, target, device, simulator)
     lipo_log = `lipo -create -output #{executable_path} #{device_lib} #{simulator_lib}`
     puts lipo_log unless File.exist?(executable_path)
 
-    FileUtils.mv executable_path, device_lib
-    FileUtils.mv device_framework_lib, build_dir
+    FileUtils.mv executable_path, device_lib, :force => true
+    FileUtils.mv device_framework_lib, build_dir, :force => true
     FileUtils.rm simulator_lib if File.file?(simulator_lib)
     FileUtils.rm device_lib if File.file?(device_lib)
   end


### PR DESCRIPTION
When adding dependencies that have the same sub-dependencies i.e. AWSLambda and AWSS3 which both depend on AWSCore I was getting an exception such as the following:

Errno::EEXIST - File exists - /Users/bphilip1/Projects/ProgressiveApp/iOS/build/AWSCognito.framework
/Users/bphilip1/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:522:in `block in mv'
/Users/bphilip1/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1571:in `block in fu_each_src_dest'
/Users/bphilip1/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1585:in `fu_each_src_dest0'
/Users/bphilip1/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:1569:in `fu_each_src_dest'
/Users/bphilip1/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/fileutils.rb:517:in `mv'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-rome-0.8.0/lib/cocoapods-rome/post_install.rb:28:in `block in build_for_iosish_platform'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-rome-0.8.0/lib/cocoapods-rome/post_install.rb:16:in `each'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-rome-0.8.0/lib/cocoapods-rome/post_install.rb:16:in `build_for_iosish_platform'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-rome-0.8.0/lib/cocoapods-rome/post_install.rb:54:in `block (2 levels) in <top (required)>'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-rome-0.8.0/lib/cocoapods-rome/post_install.rb:52:in `each'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-rome-0.8.0/lib/cocoapods-rome/post_install.rb:52:in `block in <top (required)>'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/hooks_manager.rb:111:in `block (3 levels) in run'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/user_interface.rb:142:in `message'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/hooks_manager.rb:103:in `block (2 levels) in run'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/hooks_manager.rb:101:in `each'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/hooks_manager.rb:101:in `block in run'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/user_interface.rb:142:in `message'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/hooks_manager.rb:100:in `run'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/installer.rb:493:in `run_plugins_post_install_hooks'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/installer.rb:472:in `perform_post_install_actions'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/installer.rb:121:in `install!'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/command/install.rb:37:in `run'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/lib/cocoapods/command.rb:50:in `run'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/gems/cocoapods-1.1.1/bin/pod:55:in `<top (required)>'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/bin/pod:23:in `load'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/bin/pod:23:in `<main>'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
/Users/bphilip1/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>’

This pull request fixes this problem by force overwriting the built dependency.
```ruby
FileUtils.mv device_framework_lib, build_dir, :force => true
```