### PR TITLE
Add pre post install handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,35 @@ $ tree Rome/
 Rome/
 └── Alamofire.framework
 ```
+
+## Hooks
+
+The plugin allows you to provides hooks that will be called during the installation process.
+
+### pre_compile
+
+This hook allows you to make any last changes to the generated Xcode project before the compilation of frameworks begins.
+
+It receives the `Pod::Installer` as its only argument.
+
+#### Example
+
+Customising the Swift version of all pods
+
+```ruby
+platform :osx, '10.10'
+
+plugin 'cocoapods-rome', :pre_compile => Proc.new { |installer|
+    installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+            config.build_settings['SWIFT_VERSION'] = '4.0'
+        end
+    end
+
+    installer.pods_project.save
+}
+
+target 'caesar' do
+    pod 'Alamofire'
+end
+```

--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -38,7 +38,11 @@ def xcodebuild(sandbox, target, sdk='macosx', deployment_target=nil)
   Pod::Executable.execute_command 'xcodebuild', args, true
 end
 
-Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_context|
+Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_context, user_options|
+  if user_options["pre_compile"]
+    user_options["pre_compile"].call(installer_context)
+  end
+
   sandbox_root = Pathname(installer_context.sandbox_root)
   sandbox = Pod::Sandbox.new(sandbox_root)
 


### PR DESCRIPTION
As highlighted in issue #60 one often needs to customise the way the single pods are compiled.

This PR adds a pre post install handler that allows to customize the Pods.xcodeproj file before compilation actually starts.

A sample Podfile looks like the following:

```
use_frameworks!

plugin 'cocoapods-rome', :pre_post_install => Proc.new { |installer|
    # do stuff with installer, for example change SWIFT_VERSION
    installer.pods_project.targets.each do |target|
        target.build_configurations.each do |config|
            config.build_settings['SWIFT_VERSION'] = '4.0'
        end
    end

    installer.pods_project.save
}

target 'DummyTarget' do
    pod 'MyPod'
end
```