### PR TITLE
Add post compile hook

### DIFF
--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -122,4 +122,8 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
   copy_dsym_files(sandbox_root.parent + 'dSYM', configuration) if enable_dsym
 
   build_dir.rmtree if build_dir.directory?
+
+  if user_options["post_compile"]
+    user_options["post_compile"].call(installer_context)
+  end
 end


### PR DESCRIPTION
# What's in here

This adds another hook that will execute _after_ the dependencies have been compiled and moved to the Rome directory. This was needed for us as the `post_install` hook from CocoaPods executes before the compilation, as does the `pre_compile` obviously 😄
I think this can be valuable for a broader audience, if they need to perform some actions after the compilation finished.