### PR TITLE
Manu force builddir use installed sandbox

### DIFF
--- a/cocoapods-rome.gemspec
+++ b/cocoapods-rome.gemspec
@@ -18,7 +18,7 @@ Xcode}
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "cocoapods", '1.8.0.beta.1'
+  spec.add_dependency 'cocoapods', '>= 1.1.0', '< 2.0'
   spec.add_dependency "fourflusher", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
This PR provides a few improvements:

- Rome was not working for local pods with vendored_library values set. Reason and fix:
  - If we create a new sandbox object here, `development_pods` value would
be nil because it's only saved when `store_local_path` methods is called.
This makes file_accessor to fail when looking for vendored_libraries for
local pods. Using sandbox in installer context fixes this issue.

- Rome assumes that build products will exist under
`Pods/../build` after build is completed, and it's default behavior of CP
due to setting of `SYMROOT` as `'${SRCROOT}/../build'`. This breaks
projects which provides a custom symroot during `post_install`.
  - I decided to override build dir for xcodebuild as building for Rome should
be kept separated from actual development lifecycle.