### PR TITLE
XCode 12 Support

### DIFF
--- a/cocoapods-rome.gemspec
+++ b/cocoapods-rome.gemspec
@@ -18,7 +18,7 @@ Xcode}
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "cocoapods", '1.8.0.beta.1'
+  spec.add_dependency "cocoapods", "~> 1.9.0"
   spec.add_dependency "fourflusher", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/cocoapods-rome/gem_version.rb
+++ b/lib/cocoapods-rome/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsRome
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -9,7 +9,7 @@ def build_for_iosish_platform(sandbox, build_dir, target, device, simulator, con
   target_label = target.cocoapods_target_label
 
   xcodebuild(sandbox, target_label, device, deployment_target, configuration)
-  xcodebuild(sandbox, target_label, simulator, deployment_target, configuration)
+  xcodebuild(sandbox, target_label, simulator, deployment_target, configuration, 'ARCHS=x86_64')
 
   spec_names = target.specs.map { |spec| [spec.root.name, spec.root.module_name] }.uniq
   spec_names.each do |root_name, module_name|
@@ -30,8 +30,11 @@ def build_for_iosish_platform(sandbox, build_dir, target, device, simulator, con
   end
 end
 
-def xcodebuild(sandbox, target, sdk='macosx', deployment_target=nil, configuration)
+def xcodebuild(sandbox, target, sdk='macosx', deployment_target=nil, configuration='Debug', build_settings=nil)
   args = %W(-project #{sandbox.project_path.realdirpath} -scheme #{target} -configuration #{configuration} -sdk #{sdk})
+  if build_settings 
+    args.append(build_settings)
+  end
   platform = PLATFORMS[sdk]
   args += Fourflusher::SimControl.new.destination(:oldest, platform, deployment_target) unless platform.nil?
   Pod::Executable.execute_command 'xcodebuild', args, true


### PR DESCRIPTION
When using Rome on XCode 12, we get an error when merging the Simulator and Device frameworks.
```
fatal error: /Applications/Xcode12.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo: 
/Users/{REDACTED}/Rome/build/Release-iphoneos/FBSDKCoreKit/FBSDKCoreKit.framework/FBSDKCoreKit 
and 
/Users/{REDACTED}/Rome/build/Release-iphonesimulator/FBSDKCoreKit/FBSDKCoreKit.framework/FBSDKCoreKit 
have the same architectures (arm64) and can't be in the same fat output file
```


That happens because when compiling for a Simulator on XCode 12, we end up with both `x86_64` and `arm64` binaries(thanks to the new arm Macs).
To fix the problem I added a build setting to build only `x86_64` architecture when building for the Simulator, that way we can merge it normally after both are compiled.

I still need help with 2 things.
- Does the `arm64` binary built for a device work normally in the `arm64` simulator in new macs?
- Could I instead simply build it for Simulator and use the `arm64` slice to run it on a Device? And would it cause problems with the `dsym` files?

The fix worked for me and may help some other people having this same error, but I'm not sure if I'm breaking the Simulator support on arm Macs, so any help would be appreciated.


